### PR TITLE
Fixed crash when input URL is a resource

### DIFF
--- a/linkpreview/src/main/java/com/mega4tech/linkpreview/LinkUtil.java
+++ b/linkpreview/src/main/java/com/mega4tech/linkpreview/LinkUtil.java
@@ -93,7 +93,13 @@ public class LinkUtil {
 
                     String site = "";
                     Document doc = null;
-                    doc = Jsoup.parse(response.body().string());
+                    try {
+                        doc = Jsoup.parse(response.body().string());
+                    } catch (Exception exception) {
+                        if (listener != null)
+                            listener.onFailed(exception);
+                        return;
+                    }
                     titleElements = doc.select("title");
                     descriptionElements = doc.select("meta[name=description]");
 


### PR DESCRIPTION
Caught 'IllegalArgumentException: String must not be empty' thrown by Jsoup when input URL is a resource file.